### PR TITLE
Prioritize 'v*' tag and use a new convention for the tag names

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ You can download the zip packages from the [releases](https://github.com/univers
 
 Four types of packages are provided:
 
-* `ctags-YYYY-MM-DD_{CommitID}-x64.zip`: x64 release build
-* `ctags-YYYY-MM-DD_{CommitID}-x64.debug.zip`: x64 debug build
-* `ctags-YYYY-MM-DD_{CommitID}-x86.zip`: x86 release build
-* `ctags-YYYY-MM-DD_{CommitID}-x86.debug.zip`: x86 debug build
+* `ctags-{ctagsver}-x64.zip`: x64 release build
+* `ctags-{ctagsver}-x64.debug.zip`: x64 debug build
+* `ctags-{ctagsver}-x86.zip`: x86 release build
+* `ctags-{ctagsver}-x86.debug.zip`: x86 debug build
 
-`{CommitID}` is a commit ID or a tag name of the [ctags repository](https://github.com/universal-ctags/ctags).
+`{ctagsver}` is an exact tag name of the [ctags repository](https://github.com/universal-ctags/ctags) or a generated name in the format of `YYYY-MM-DD_{tag}-N-gHHHHHHHH`.
 Normally you may want to use the release builds. If you need unstripped binaries for debugging, use the debug builds.
 
 # Note

--- a/scripts/update-repo.sh
+++ b/scripts/update-repo.sh
@@ -26,7 +26,7 @@ git submodule update
 cd ctags
 git checkout master
 git pull --no-edit --ff-only
-ctagsver=$(git describe --tags --always)
+ctagsver=$(git describe --tags --exact-match --match 'v*' 2> /dev/null || git describe --tags --always)
 cd ..
 ctagslog=$(git submodule summary | grep '^  > ')
 

--- a/scripts/update-repo.sh
+++ b/scripts/update-repo.sh
@@ -45,5 +45,12 @@ echo "$ctagslog" | \
 	perl -pe 's/\n/\\n/g' > gitlog.txt
 ctagslog=$(echo "$ctagslog" | sed -e 's/^  >/*/')
 git commit -a -m "ctags: Update to $ctagsver" -m "$ctagslog"
-git tag $(date --rfc-3339=date)/$ctagsver
+case "$ctagsver" in
+	v* | p*.*.*.0)
+		git tag "$ctagsver"
+		;;
+	*)
+		git tag "$(date --rfc-3339=date)/$ctagsver"
+		;;
+esac
 git push origin master --tags


### PR DESCRIPTION
Prioritize `v*` tag over other tags like `p*`.

Also use a new convention for the tag names.
If the latest commit of the ctags repository is tagged and if the format of the tag is
`v*` (e.g. `v6.0.0`) or `p*.*.*.0` (e.g. `p5.9.20201011.0`) use the exact tag name.
Otherwise, use the `YYYY-MM-DD/{tag}-N-gHHHHHHHH` format.
