### PR TITLE
Create releases only on universal-ctags/ctags-win32

### DIFF
--- a/.github/workflows/build-ctags.yaml
+++ b/.github/workflows/build-ctags.yaml
@@ -191,7 +191,8 @@ jobs:
   release:
     runs-on: windows-latest
     needs: [build]
-    if: (github.event_name != 'pull_request') && (needs.build.outputs.skip == 'no')
+    # Create releases only on the 'universal-ctags/ctags-win32' repository.
+    if: (github.event_name != 'pull_request') && (needs.build.outputs.skip == 'no') && (github.repository == 'universal-ctags/ctags-win32')
 
     defaults:
       run:


### PR DESCRIPTION
Create releases only on the 'universal-ctags/ctags-win32' repository.