### PR TITLE
CI: Update package name

### DIFF
--- a/.github/workflows/build-ctags.yaml
+++ b/.github/workflows/build-ctags.yaml
@@ -153,7 +153,7 @@ jobs:
         msystem: ${{ matrix.msystem }}
         update: true
         install: git make automake autoconf
-        pacboy: toolchain:p python3-sphinx:p jansson:p libxml2:p libyaml:p pcre2:p
+        pacboy: toolchain:p python-sphinx:p jansson:p libxml2:p libyaml:p pcre2:p
 
     - name: Build
       if: steps.check.outputs.skip == 'no'


### PR DESCRIPTION
Recently the package name python3-sphinx has been renamed to python-sphinx.