### PR TITLE
package: Drop CLANG32 builds

### DIFF
--- a/.github/workflows/build-ctags.yaml
+++ b/.github/workflows/build-ctags.yaml
@@ -48,7 +48,6 @@ jobs:
           - { arch: x64,       msystem: MINGW64 }
           - { arch: x86,       msystem: MINGW32 }
           - { arch: clang-x64, msystem: CLANG64 }
-          - { arch: clang-x86, msystem: CLANG32 }
 
     outputs:
       skip: ${{ steps.check.outputs.skip }}

--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ There are also experimental packages that are built with Clang and linked agains
 
 * `ctags-{ctagsver}-clang-x64.zip`: x64 package built with Clang
 * `ctags-{ctagsver}-clang-x64.debuginfo.zip`: clang-x64 debug symbol files
-* `ctags-{ctagsver}-clang-x86.zip`: x86 package built with Clang
-* `ctags-{ctagsver}-clang-x86.debuginfo.zip`: clang-x86 debug symbol files
 
 Hopefully, the issue reported at [#3014](https://github.com/universal-ctags/ctags/issues/3014) is solved.
 


### PR DESCRIPTION
The CLANG32 environment is going to be deprecated. Stop supporting it.
See: https://www.msys2.org/news/#2024-09-23-starting-to-drop-the-clang32-environment